### PR TITLE
proposed protocol cleanup: zip urls and byteRanges, and eliminate sizes

### DIFF
--- a/client/htsnexus.py
+++ b/client/htsnexus.py
@@ -59,8 +59,7 @@ def get(namespace, accession, format, verbose=False, **kwargs):
         sys.stdout.flush()
 
     # pipe the raw data
-    i = 0
-    for url in ticket['urls']:
+    for item in ticket['urls']:
         # delegate to curl to access the URL given in the ticket, including any
         # HTTP request headers htsnexus instructed us to supply.
         curlcmd = ['curl','-LSs']
@@ -69,15 +68,14 @@ def get(namespace, accession, format, verbose=False, **kwargs):
                 curlcmd.append('-H')
                 curlcmd.append(str(k + ': ' + v))
         # add the byte range header if we're slicing
-        if 'byteRanges' in ticket:
+        if 'byteRange' in item:
             curlcmd.append('-H')
-            curlcmd.append('range: bytes=' + str(ticket['byteRanges'][i]['start']) + '-' + str(ticket['byteRanges'][i]['end']-1))
-        curlcmd.append(str(url))
+            curlcmd.append('range: bytes=' + str(item['byteRange']['start']) + '-' + str(item['byteRange']['end']-1))
+        curlcmd.append(str(item['url']))
         if verbose:
             print >>sys.stderr, ('Piping: ' + str(curlcmd))
             sys.stderr.flush()
         subprocess.check_call(curlcmd)
-        i = i + 1
 
     # emit the suffix blob, if the ticket so instructs us; this typically consists
     # of the format-defined EOF marker when taking a genomic range slice.

--- a/client/htsnexus.py
+++ b/client/htsnexus.py
@@ -63,14 +63,10 @@ def get(namespace, accession, format, verbose=False, **kwargs):
         # delegate to curl to access the URL given in the ticket, including any
         # HTTP request headers htsnexus instructed us to supply.
         curlcmd = ['curl','-LSs']
-        if 'httpRequestHeaders' in ticket:
-            for k, v in ticket['httpRequestHeaders'].items():
+        if 'headers' in item:
+            for k, v in item['headers'].items():
                 curlcmd.append('-H')
                 curlcmd.append(str(k + ': ' + v))
-        # add the byte range header if we're slicing
-        if 'byteRange' in item:
-            curlcmd.append('-H')
-            curlcmd.append('range: bytes=' + str(item['byteRange']['start']) + '-' + str(item['byteRange']['end']-1))
         curlcmd.append(str(item['url']))
         if verbose:
             print >>sys.stderr, ('Piping: ' + str(curlcmd))

--- a/server/src/htsfiles_routes._js
+++ b/server/src/htsfiles_routes._js
@@ -42,14 +42,14 @@ class HTSRoutes {
             accession: request.params.accession,
             // format was given to us in lowercase for legacy reasons (reuse v0 database for v1 server)
             format: format.toUpperCase(),
-            urls: [info.url],
+            urls: [{url: info.url}],
             httpRequestHeaders: {
                 "referer": request.connection.info.protocol + '://' + request.info.host + request.url.path
             }
         };
 
         if (typeof info.file_size === 'number') {
-            ans.byteRanges = [{ start : 0, end : info.file_size }];
+            ans.urls[0].byteRange = { start : 0, end : info.file_size };
         }
 
         // genomic range slicing
@@ -90,11 +90,10 @@ class HTSRoutes {
                 let lo = rslt['min(byteLo)'];
                 let hi = rslt['max(byteHi)'];
                 // reporting byteRange as zero-based, half-open
-                ans.byteRanges = [{ start : lo, end : hi }];
+                ans.urls[0].byteRange = { start : lo, end : hi };
             } else {
                 // empty result set
                 ans.urls = [];
-                delete ans.byteRanges;
             }
 
             // TODO: handle block_suffix as well.
@@ -124,14 +123,14 @@ class HTSRoutes {
         let ans = {
             namespace: request.params.namespace,
             accession: request.params.accession,
-            urls: ["http://bamsvr.herokuapp.com/get?ac=" + encodeURIComponent(request.params.accession)],
+            urls: [{url: "http://bamsvr.herokuapp.com/get?ac=" + encodeURIComponent(request.params.accession)}],
             format: "BAM"
         }
 
        if (request.query.referenceName) {
             let genomicRange = resolveGenomicRange(request.query);
-            ans.urls[0] += "&seq=" + encodeURIComponent(genomicRange.seq) +
-                           "&start=" + genomicRange.lo + "&end=" + genomicRange.hi;
+            ans.urls[0].url += "&seq=" + encodeURIComponent(genomicRange.seq) +
+                               "&start=" + genomicRange.lo + "&end=" + genomicRange.hi;
         }
 
         return ans;

--- a/server/test/test._js
+++ b/server/test/test._js
@@ -77,6 +77,7 @@ describe("Server", function() {
             let res = req("/reads/htsnexus_test/NA12878?referenceName=20&start=6000000&end=6020000", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.urls[0].url).to.be.a('string');
+            expect(res.body.urls[0].headers.range).to.be("bytes=977196-1165272");
             expect(res.body.reference).to.be('GRCh37');
             expect(res.body.format).to.be('BAM');
 
@@ -85,9 +86,6 @@ describe("Server", function() {
             expect(buf[0]).to.be(0x1f);
             expect(buf[1]).to.be(0x8b);
 
-            expect(res.body.urls[0].byteRange.start).to.be(977196);
-            expect(res.body.urls[0].byteRange.end).to.be(1165273);
-
             expect(res.body.suffix).to.be.a('string');
             buf = new Buffer(res.body.suffix, 'base64');
             expect(buf[0]).to.be(0x1f);
@@ -95,16 +93,14 @@ describe("Server", function() {
             expect(buf.length).to.be(28);
 
             res = req("/reads/htsnexus_test/NA12878?format=BAM&referenceName=20&start=5000000&end=6020000", _);
-            expect(res.body.urls[0].byteRange.start).to.be(977196);
-            expect(res.body.urls[0].byteRange.end).to.be(1165273);
+            expect(res.body.urls[0].headers.range).to.be("bytes=977196-1165272");
         });
 
         it("should suppress BAM header slice prefix on request", function(_) {
             let res = req("/reads/htsnexus_test/NA12878?referenceName=20&start=6000000&end=6020000&noHeaderPrefix", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange.start).to.be(977196);
-            expect(res.body.urls[0].byteRange.end).to.be(1165273);
+            expect(res.body.urls[0].headers.range).to.be("bytes=977196-1165272");
             expect(res.body.format).to.be('BAM');
             expect(res.body.reference).to.be('GRCh37');
             expect(res.body.prefix).to.be(undefined);
@@ -114,8 +110,7 @@ describe("Server", function() {
             let res = req("/reads/htsnexus_test/NA12878?referenceName=20", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange.start).to.be(977196);
-            expect(res.body.urls[0].byteRange.end).to.be(2128166);
+            expect(res.body.urls[0].headers.range).to.be("bytes=977196-2128165");
             expect(res.body.format).to.be('BAM');
             expect(res.body.reference).to.be('GRCh37');
 
@@ -135,8 +130,7 @@ describe("Server", function() {
             let res = req("/reads/htsnexus_test/NA12878?referenceName=*", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange.start).to.be(2112141);
-            expect(res.body.urls[0].byteRange.end).to.be(2596771);
+            expect(res.body.urls[0].headers.range).to.be("bytes=2112141-2596770");
             expect(res.body.format).to.be('BAM');
             expect(res.body.reference).to.be('GRCh37');
 
@@ -189,14 +183,14 @@ describe("Server", function() {
             expect(res.statusCode).to.be(200);
             expect(res.body.format).to.be('BAM');
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange).to.be(undefined);
+            expect(res.body.urls[0].headers).to.be(undefined);
 
             res = req("/reads/lh3bamsvr/EXA00001?referenceName=11:10899000&end=10900000", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.format).to.be('BAM');
             expect(res.body.prefix).to.be(undefined);
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange).to.be(undefined);
+            expect(res.body.urls[0].headers).to.be(undefined);
             expect(res.body.suffix).to.be(undefined);
         });
     });
@@ -207,8 +201,7 @@ describe("Server", function() {
             expect(res.statusCode).to.be(200);
             expect(res.headers['access-control-allow-origin']).to.be('https://www.dnanexus.com');
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange.start).to.be(0);
-            expect(res.body.urls[0].byteRange.end).to.be(1661526);
+            expect(res.body.urls[0].headers.range).to.be("bytes=0-1661525");
             expect(res.body.format).to.be('CRAM');
         });
 
@@ -216,8 +209,7 @@ describe("Server", function() {
             let res = req("/reads/htsnexus_test/NA12878?format=CRAM&referenceName=20&start=6000000&end=6020000", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange.start).to.be(617115);
-            expect(res.body.urls[0].byteRange.end).to.be(1094993);
+            expect(res.body.urls[0].headers.range).to.be("bytes=617115-1094992");
             expect(res.body.format).to.be('CRAM');
             expect(res.body.reference).to.be('GRCh37');
 
@@ -232,16 +224,14 @@ describe("Server", function() {
             expect(buf.length).to.be(38);
 
             res = req("/reads/htsnexus_test/NA12878?format=CRAM&referenceName=20&start=5000000&end=6020000", _);
-            expect(res.body.urls[0].byteRange.start).to.be(617115);
-            expect(res.body.urls[0].byteRange.end).to.be(1094993);
+            expect(res.body.urls[0].headers.range).to.be("bytes=617115-1094992");
         });
 
         it("should suppress CRAM header slice prefix on request", function(_) {
             let res = req("/reads/htsnexus_test/NA12878?format=CRAM&referenceName=20&start=6000000&end=6020000&noHeaderPrefix", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange.start).to.be(617115);
-            expect(res.body.urls[0].byteRange.end).to.be(1094993);
+            expect(res.body.urls[0].headers.range).to.be("bytes=617115-1094992");
             expect(res.body.format).to.be('CRAM');
             expect(res.body.reference).to.be('GRCh37');
             expect(res.body.prefix).to.be(undefined);
@@ -251,8 +241,7 @@ describe("Server", function() {
             let res = req("/reads/htsnexus_test/NA12878?format=CRAM&referenceName=20", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange.start).to.be(617115);
-            expect(res.body.urls[0].byteRange.end).to.be(1310237);
+            expect(res.body.urls[0].headers.range).to.be("bytes=617115-1310236");
             expect(res.body.format).to.be('CRAM');
             expect(res.body.reference).to.be('GRCh37');
 
@@ -271,8 +260,7 @@ describe("Server", function() {
             let res = req("/reads/htsnexus_test/NA12878?format=CRAM&referenceName=*", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.urls[0].url).to.be.a('string');
-            expect(res.body.urls[0].byteRange.start).to.be(1310237);
-            expect(res.body.urls[0].byteRange.end).to.be(1661488);
+            expect(res.body.urls[0].headers.range).to.be("bytes=1310237-1661487");
             expect(res.body.format).to.be('CRAM');
             expect(res.body.reference).to.be('GRCh37');
 
@@ -291,7 +279,7 @@ describe("Server", function() {
             let res = req("/reads/htsnexus_test/NA12878?format=CRAM&referenceName=20&start=1&end=10000", _);
             expect(res.statusCode).to.be(200);
             expect(res.body.format).to.be('CRAM');
-            expect(res.body.byteRanges).to.be(undefined);
+            expect(res.body.urls.length).to.be(0);
 
             expect(res.body.prefix).to.be.a('string');
             let buf = new Buffer(res.body.prefix, 'base64');
@@ -305,7 +293,7 @@ describe("Server", function() {
 
             res = req("/reads/htsnexus_test/NA12878?format=CRAM&referenceName=XXX", _);
             expect(res.statusCode).to.be(200);
-            expect(res.body.byteRanges).to.be(undefined);
+            expect(res.body.urls.length).to.be(0);
         });
     });
 


### PR DESCRIPTION
Instead of arrays constrained to be the same length, zip urls and byteRanges e.g.:

```
urls: [{url: "https://xxxx", byteRange: {start: 1000, end: 2000}}, ...]
````

Furthermore we can eliminate the `sizes` field. If the server knows the file size, it can fill that into `byteRange` if not slicing.